### PR TITLE
Update for newer tang versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,13 +40,8 @@ kgen = find_program([
   '/usr/libexec/tangd-keygen',
   '/usr/local/libexec/tangd-keygen',
 ], required: false)
-updt = find_program([
-  join_paths(libexecdir, 'tangd-update'),
-  '/usr/libexec/tangd-update',
-  '/usr/local/libexec/tangd-update',
-], required: false)
 
-if tang.found() and kgen.found() and updt.found() and actv.found()
+if tang.found() and kgen.found() and actv.found()
   env = environment()
   env.append('PATH',
     meson.current_build_dir(),

--- a/tang
+++ b/tang
@@ -28,15 +28,13 @@ trap 'exit' ERR
 
 export TMP=`mktemp -d`
 mkdir -p $TMP/db
-mkdir -p $TMP/cache
 
 # Generate the server keys
 tangd-keygen $TMP/db
-tangd-update $TMP/db $TMP/cache
 
 # Start the server
 port=`shuf -i 1024-65536 -n 1`
-systemd-socket-activate --inet -l 127.0.0.1:$port -a $VALGRIND tangd $TMP/cache &
+systemd-socket-activate --inet -l 127.0.0.1:$port -a $VALGRIND tangd $TMP/db &
 export PID=$!
 sleep 0.5
 


### PR DESCRIPTION
In commit 7119454, tang eliminated tangd-update and moved that
functionality to the tang process itself. This requires some adjustments
here.